### PR TITLE
Quick fix problem with newer versions of Alice

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "doctrine/common": "~2.0",
-        "nelmio/alice": "~1.5||~2.0",
+        "nelmio/alice": "~1.5||<=2.1.0",
         "php": ">=5.4",
         "symfony/dependency-injection": "~2.0",
         "symfony/finder": "~2.0",


### PR DESCRIPTION
Alice v2.1.1 requires first constructor parameter to be PersisterInterface
