### PR TITLE
Added Doctrine persister

### DIFF
--- a/src/Knp/Rad/FixturesLoad/FixturesFactory.php
+++ b/src/Knp/Rad/FixturesLoad/FixturesFactory.php
@@ -4,6 +4,7 @@ namespace Knp\Rad\FixturesLoad;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use Nelmio\Alice\Fixtures;
+use Nelmio\Alice\Persister\Doctrine;
 use Nelmio\Alice\ProcessorInterface;
 
 class FixturesFactory
@@ -58,6 +59,8 @@ class FixturesFactory
             $options['locale'] = $locale;
         }
 
-        return new Fixtures($om, $options, $this->processors);
+        $doctrinePersister = new Doctrine($om);
+
+        return new Fixtures($doctrinePersister, $options, $this->processors);
     }
 }


### PR DESCRIPTION
Better fix of 

Catchable Fatal Error: Argument 1 passed to Nelmio\Alice\Fixtures::__construct() must be an instance of Nelmio\Alice\PersisterInterface, instance of Doctrine\ORM\EntityManager given

Instead of quick patch of composer.json I instantiated Doctrine Persister from Alice
