### PR TITLE
Rename connection parameter by manager and delete default value.

### DIFF
--- a/src/Knp/Rad/FixturesLoad/Command/FixturesCommand.php
+++ b/src/Knp/Rad/FixturesLoad/Command/FixturesCommand.php
@@ -35,11 +35,10 @@ class FixturesCommand extends ContainerAwareCommand
                 'Filter importable files via name suffix (dev => *.dev.yml).'
             )
             ->addOption(
-                'connection',
-                'c',
+                'manager',
+                'm',
                 InputOption::VALUE_OPTIONAL,
-                'Doctrine connection to use',
-                'default'
+                'Doctrine connection to use'
             )
             ->addOption(
                 'locale',
@@ -100,7 +99,7 @@ class FixturesCommand extends ContainerAwareCommand
             $this->getLoader()->loadFixtures(
                 $bundle,
                 $filters,
-                $input->getOption('connection'),
+                $input->getOption('manager'),
                 $input->getOption('locale')
             );
         }


### PR DESCRIPTION
`connection` parameter shall not be named like that, it's not the dbal connection but the orm/odm object manager used to load fixtures.
Also, using `default` as default value is a bad idea: the default entity manager is configurable via `doctrine.orm.default_entity_manager` parameter.
