### PR TITLE
[WIP] Added support to load fixtures from app directory

### DIFF
--- a/src/Knp/Rad/FixturesLoad/Command/FixturesCommand.php
+++ b/src/Knp/Rad/FixturesLoad/Command/FixturesCommand.php
@@ -3,7 +3,7 @@
 namespace Knp\Rad\FixturesLoad\Command;
 
 use Knp\Rad\FixturesLoad\Events;
-use Knp\Rad\FixturesLoad\Formater\BundleFormater;
+use Knp\Rad\FixturesLoad\Formater\PathFormater;
 use Knp\Rad\FixturesLoad\Formater\FileFormater;
 use Knp\Rad\FixturesLoad\Formater\ObjectsFormater;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
@@ -79,7 +79,7 @@ class FixturesCommand extends ContainerAwareCommand
         $filters = [];
         $filters = array_merge($filters, array_map(function ($e) { return sprintf('*.%s.yml', $e); }, $input->getOption('filter')));
         $filters = array_merge($filters, array_map(function ($e) { return sprintf('*.%s.php', $e); }, $input->getOption('filter')));
-        
+
         if (true === empty($filters)) {
             $filters = ['*.yml', '*.php'];
         }
@@ -99,9 +99,16 @@ class FixturesCommand extends ContainerAwareCommand
             );
         }
 
+        $this->getLoader()->loadFixtures(
+            $this->getKernelRootDir(),
+            $filters,
+            $input->getOption('manager'),
+            $input->getOption('locale')
+        );
+
         foreach ($bundles as $bundle) {
             $this->getLoader()->loadFixtures(
-                $bundle,
+                $bundle->getPath(),
                 $filters,
                 $input->getOption('manager'),
                 $input->getOption('locale')
@@ -150,6 +157,11 @@ class FixturesCommand extends ContainerAwareCommand
         return $this->getContainer()->get('knp_rad_fixtures_load.reset_schema_processor');
     }
 
+    private function getKernelRootDir()
+    {
+        return $this->getContainer()->getParameter('kernel.root_dir');
+    }
+
     /**
      * @param OutputInterface $output
      * @param bool            $verbosity
@@ -159,7 +171,7 @@ class FixturesCommand extends ContainerAwareCommand
     private function getFormaters(OutputInterface $output, $verbosity)
     {
         $formaters = [
-            new BundleFormater(),
+            new PathFormater(),
             new FileFormater(),
             new ObjectsFormater(),
         ];

--- a/src/Knp/Rad/FixturesLoad/Event.php
+++ b/src/Knp/Rad/FixturesLoad/Event.php
@@ -3,14 +3,13 @@
 namespace Knp\Rad\FixturesLoad;
 
 use Symfony\Component\EventDispatcher\Event as BaseEvent;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class Event extends BaseEvent
 {
     /**
-     * @var Bundle
+     * @var string
      */
-    private $bundle;
+    private $path;
 
     /**
      * @var string
@@ -23,12 +22,12 @@ class Event extends BaseEvent
     private $objects;
 
     /**
-     * @param Bundle $bundle
+     * @param string $path
      * @param string $file
      */
-    public function __construct(Bundle $bundle, $file)
+    public function __construct($path, $file)
     {
-        $this->bundle = $bundle;
+        $this->path = $path;
         $this->file   = $file;
     }
 
@@ -45,11 +44,11 @@ class Event extends BaseEvent
     }
 
     /**
-     * @return Bundle
+     * @return string
      */
-    public function getBundle()
+    public function getPath()
     {
-        return $this->bundle;
+        return $this->path;
     }
 
     /**

--- a/src/Knp/Rad/FixturesLoad/Formater/PathFormater.php
+++ b/src/Knp/Rad/FixturesLoad/Formater/PathFormater.php
@@ -6,17 +6,12 @@ use Knp\Rad\FixturesLoad\Event;
 use Knp\Rad\FixturesLoad\Formater;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class BundleFormater implements Formater
+class PathFormater implements Formater
 {
     /**
      * @var OutputInterface
      */
     private $output;
-
-    /**
-     * @var string
-     */
-    private $cache = [];
 
     /**
      * {@inheritdoc}
@@ -41,14 +36,7 @@ class BundleFormater implements Formater
      */
     public function preLoad(Event $event)
     {
-        $class = get_class($event->getBundle());
-
-        if (in_array($class, $this->cache)) {
-            return;
-        }
-
-        $this->output->writeln(sprintf('<fg=black;bg=green>#Bundle > %s </fg=black;bg=green>', $class));
-        $this->cache[] = $class;
+        $this->output->writeln(sprintf('<fg=black;bg=green>#Path > %s </fg=black;bg=green>', $event->getPath()));
     }
 
     /**

--- a/src/Knp/Rad/FixturesLoad/Loader.php
+++ b/src/Knp/Rad/FixturesLoad/Loader.php
@@ -47,15 +47,15 @@ class Loader
      * @param string      $connection
      * @param string|null $locale
      */
-    public function loadFixtures(Bundle $bundle, array $filters, $connection, $locale = null)
+    public function loadFixtures($path, array $filters, $connection, $locale = null)
     {
-        if (false === is_dir(sprintf('%s/Resources/fixtures/orm', $bundle->getPath()))) {
+        if (false === is_dir(sprintf('%s/Resources/fixtures/orm', $path))) {
             return;
         }
 
         $files = (new Finder())
             ->files()
-            ->in(sprintf('%s/Resources/fixtures/orm', $bundle->getPath()))
+            ->in(sprintf('%s/Resources/fixtures/orm', $path))
             ->sortByName()
         ;
 
@@ -64,7 +64,7 @@ class Loader
         }
 
         foreach ($files as $file) {
-            $event = new Event($bundle, $file);
+            $event = new Event($path, $file);
             $this->dispatcher->dispatch(Events::PRE_LOAD, $event);
             $event->setObjects($this->getFixtures($connection, $locale)->loadFiles($file));
             $this->dispatcher->dispatch(Events::POST_LOAD, $event);


### PR DESCRIPTION
This PR adds support to load fixtures from `app/Resources/fixtures/orm`.

This is usefull when someone is not defining a bundle in her/his `src/` directory.