### PR TITLE
Drop PHP < 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: php
 php:
-    - 5.4
-    - 5.5
-    - 5.6
     - 7.0
+    - 7.1
 
 branches:
     only:
@@ -11,13 +9,9 @@ branches:
 
 matrix:
     include:
-        - php: 5.4
-          env: 'COMPOSER_FLAGS="--prefer-lowest --prefer-stable"'
-        - php: 5.5
-          env: 'COMPOSER_FLAGS="--prefer-lowest --prefer-stable"'
-        - php: 5.6
-          env: 'COMPOSER_FLAGS="--prefer-lowest --prefer-stable"'
         - php: 7.0
+          env: 'COMPOSER_FLAGS="--prefer-lowest --prefer-stable"'
+        - php: 7.1
           env: 'COMPOSER_FLAGS="--prefer-lowest --prefer-stable"'
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "doctrine/common": "~2.0",
         "doctrine/orm": "~2.0",
         "nelmio/alice": "~1.5||~2.0",
-        "php": ">=5.4",
+        "php": "~7.0",
         "symfony/dependency-injection": "~2.3|~3.0",
         "symfony/finder": "~2.3|~3.0",
         "symfony/framework-bundle": "~2.3|~3.0",
@@ -30,10 +30,5 @@
     },
     "config": {
         "bin-dir": "bin"
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "2.0.x-dev"
-        }
     }
 }


### PR DESCRIPTION
Drops support for PHP < 7.0 and removes useless branch alias.